### PR TITLE
use inky rather than inkyphat in config.yml example

### DIFF
--- a/content/configuration/_index.md
+++ b/content/configuration/_index.md
@@ -121,7 +121,7 @@ main:
 
 ui:
     display:
-      type: 'inkyphat'
+      type: 'inky'
       color: 'black'
 ```
 


### PR DESCRIPTION
I was a little bit unsure whether to use `inky` as in mentioned in the "Select your display" or `inkyphat` as in the "First Boot" sample `config.yml` in the ["Configuration"](https://pwnagotchi.ai/configuration/) part of the docs.
I see in [`pwnagotchi/pwnagotchi/utils.py`](https://github.com/evilsocket/pwnagotchi/blob/master/pwnagotchi/utils.py) that there is code to *normalize the display name* and use `inky` when either `inky` or `inkyphat` is the configuration value.

This is a proposal to keep just 'inky' in the `config.yml` example not to confuse people.
HTH
