### PR TITLE
Make sure, text in menu is aligned

### DIFF
--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -66,6 +66,7 @@ a.highlight span.copy-to-clipboard {
 }
 
 .dd-item > a > i.fas {
+    width: 32px;
     color: #c78d08;
 }
 


### PR DESCRIPTION
Currently the text of the menu items is not aligned as the different icons have different sizes.