### PR TITLE
Some refactorings / corrections

### DIFF
--- a/content/configuration/_index.md
+++ b/content/configuration/_index.md
@@ -270,7 +270,7 @@ If you want to upload your handshakes while walking, want to use your smartphone
 {{% /notice %}}
 
 {{% notice info %}}
-<p>Make sure to explicitly enable Bluetooth Tethering on your Android Phone (usually in Settings -> Hotspot or similar. Otherwise your Pwnagotchi will tether with your phone but you won't be able to connect to it.</p>
+<p>Make sure to explicitly enable Bluetooth Tethering on your Android Phone (usually in Settings -> Hotspot or similar). Otherwise your Pwnagotchi will pair with your phone but you won't be able to connect to it.</p>
 {{% /notice %}}
 
 Now in pwnagotchi's `config.yml` add the following:

--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -101,7 +101,7 @@ Some of the supported displays support both **Black & White** and **Colored** ve
    - will always have the most updated and best supported UI elements; Pwnagotchi's primary developer ([@evilsocket](https://twitter.com/evilsocket)) will be testing new features exclusively on Waveshare V2s.
    - the continued support for other e-ink display models like the Inky pHAT depends entirely on users' continued contributions to the code.
 - **Difference between Waveshare V2 and V1 displays**
-The main difference between Waveshare 2.13inch V1 and V2 is image ghosting effect. This issue appears when partial image update is used. V2 has less ghosting issue than V1. Full screen refresh can clear old ghosting traces, so you can use plugin `screen_refresh` to redraw screen at a given interval in minutes. 
+The main difference between Waveshare 2.13inch V1 and V2 is image ghosting effect. This issue appears when partial image update is used. V2 has less ghosting issue than V1. Full screen refresh can clear old ghosting traces, so you can use plugin `screen_refresh` to redraw the screen after a configurable amount of screen updates. 
 ![Difference between Waveshare 2.13inch V1 and V2 display. Image ghosting effect on V1.](https://i.imgur.com/IUTJ4Ia.jpg)
 - Avoid the Waveshare eInk **3-color** display. The refresh time is 15 seconds.
 - Avoid the Pimoroni Inky pHAT **v1.** They're discontinued due to a faulty hardware part source used in manufacturing that resulted in high failure rates.

--- a/content/plugins/_index.md
+++ b/content/plugins/_index.md
@@ -17,7 +17,7 @@ Plugin Script | Description
 `AircrackOnly.py` | Confirms pcap contains handshake/PMKID or delete it.
 `auto-backup.py` | Backs up files when internet is available.
 `auto-update.py` | `apt update && apt upgrade` when internet is available.
-`bi-tether.py` | Makes the display reachable over bluetooth.
+`bt-tether.py` | Makes the display reachable over bluetooth.
 `example.py` | Example plugin for Pwnagotchi that implements all the available callbacks.
 `gps.py` | Saves GPS coordinates whenever a handshake is captured.
 `grid.py` | Signals the unit's cryptographic identity and (optionally) a list of pwned networks to PwnGRID at api.pwnagotchi.ai.

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -6,12 +6,12 @@
 </a>
 
 <center>
-<a href="https://github.com/evilsocket/pwnagotchi/releases/latest">
-  <img alt="Release" src="https://img.shields.io/github/release/evilsocket/pwnagotchi.svg?style=flat-square">
-</a>
+  <a href="https://github.com/evilsocket/pwnagotchi/releases/latest">
+    <img alt="Release" src="https://img.shields.io/github/release/evilsocket/pwnagotchi.svg?style=flat-square">
+  </a>
 
-<div style="height:34px">
-  <a href="https://www.patreon.com/bePatron?u=6065463" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
-</div>
+  <div style="height:34px">
+    <a href="https://www.patreon.com/bePatron?u=6065463" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+  </div>
 
 </center>

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -11,8 +11,7 @@
 </a>
 
 <div style="height:34px">
-<a href="https://www.patreon.com/bePatron?u=6065463" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+  <a href="https://www.patreon.com/bePatron?u=6065463" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
 </div>
 
 </center>
-


### PR DESCRIPTION
I found some typos, identation stuff and some infos which needed corrections.

Here is the "changelog":

* Configuration -> Bluetooth -> Info: missing closing `)` and change a word to `pair`, since pairing is meant there.
* Installation -> Waveshare v1, v2 difference: correct statement about `screen_refresh` plugin when it will redraw
* Plugins: somehow a typo slipped in naming the bluetooth plugin `bi-tether`, renaming it to `bt-tether`
* logo.html partial: around the patreon's `<a>` tag are some wrong indentations