### PR TITLE
Proper escaping for parenthesis in links

### DIFF
--- a/content/configuration/_index.md
+++ b/content/configuration/_index.md
@@ -140,7 +140,7 @@ Currently supported:
 * `waveshare_2` for the V2 version of [Waveshare's ePaper HAT](https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT), [this is the recommended and officially supported display](/installation/#required-hardware).
 * `waveshare_1` for the V1 legacy version of [Waveshare's ePaper HAT](https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT)
 * `waveshare27inch` for [2.7inch e-Paper HAT](https://www.waveshare.com/wiki/2.7inch_e-Paper_HAT)
-* `waveshare154inch` for [1.54inch e-Paper Module (B)](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B\))
+* `waveshare154inch` for [1.54inch e-Paper Module (B)](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_\(B\))
 * `inky` for [Pimoroni's Inky pHAT](https://shop.pimoroni.com/products/inky-phat).
 * `papirus` for [PaPiRus Zero](https://thepihut.com/products/papirus-zero-epaper-eink-screen-phat-for-pi-zero).
 * `oledhat` for [Waveshare's OLED Hat](https://www.waveshare.com/wiki/1.3inch_OLED_HAT).

--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -72,8 +72,8 @@ If, instead, you want to fully enjoy walking around and literally looking at you
 - **[Waveshare eInk 2.7” Display](https://www.waveshare.com/2.7inch-e-paper-hat.htm)**
   - [Product page](https://www.waveshare.com/2.7inch-e-paper-hat.htm)
   - [GitHub](https://github.com/waveshare/e-Paper/tree/master/RaspberryPi%26JetsonNano/python)
-- [Waveshare eInk 1.54” Display Module (B)](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B\))
-  - [Product page](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B\))
+- [Waveshare eInk 1.54” Display Module (B)](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_\(B\))
+  - [Product page](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_\(B\))
   - [GitHub](https://github.com/waveshare/e-Paper/tree/master/RaspberryPi%26JetsonNano/python)
 - [Pimoroni Inky pHAT](https://shop.pimoroni.com/products/inky-phat)
   - [Product page](https://shop.pimoroni.com/products/inky-phat)


### PR DESCRIPTION
The links to the 1.54inch e-Paper Module (B) are displayed wrong due to parenthesis usage in the link and problems with escaping.

My markdown plugin in intelliJ did not need to escape the `(` but hugo needs it.