### PR TITLE
changeme YML snippet adopts same style as other YML

### DIFF
--- a/content/usage/_index.md
+++ b/content/usage/_index.md
@@ -53,9 +53,10 @@ The username and password for the web UI are both `changeme` by default.
 You should change these by updating the `config.yml` to include the new username and password. For example:
 
 ```yaml
+ui:
     web:
-      username: my_new_username
-      password: my_new_password
+        username: my_new_username
+        password: my_new_password
 ```
 
 #### The e-ink display (optional)


### PR DESCRIPTION
When referencing a YML snippet we should include the whole path, not just the subtree. (As per 'Configuring' page). Using 4 spaces per indent.

