### PR TITLE
alias pwnlog: increase specificity to prevent undesirable output

### DIFF
--- a/content/usage/_index.md
+++ b/content/usage/_index.md
@@ -280,7 +280,7 @@ the new image and restore the backup by extracting the files back in the root fi
 ### pwnlog
 Putting this into your .bashrc will create the `pwnlog` alias which is a pretty and uncluttered view on the pwnagotchi logs.
 ```bash
-alias pwnlog='tail -f -n300 /var/log/pwn* | sed --unbuffered "s/,[[:digit:]]\{3\}\]//g" | cut -d " " -f 2-'
+alias pwnlog='tail -f -n300 /var/log/pwn*.log | sed --unbuffered "s/,[[:digit:]]\{3\}\]//g" | cut -d " " -f 2-'
 ```
 
 ### pwnver


### PR DESCRIPTION
by adjusting the alias to *.logs it will not output wingdings and beeps to console which might be undesirable to some users and confusing to new users learning as they go.